### PR TITLE
table-inspection code made futureproof for cassio 0.1.0 in qa-basic

### DIFF
--- a/docs/frameworks/langchain/.colab/colab_qa-basic.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_qa-basic.ipynb
@@ -336,7 +336,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LLM+embeddings from Vertex AI\n"
+      "LLM+embeddings from OpenAI\n"
      ]
     }
    ],
@@ -514,22 +514,22 @@
      "text": [
       "\n",
       "Row 0:\n",
-      "    document_id:      21fbd9985564f7f12ac51f4c20232d75\n",
-      "    embedding_vector: [-0.011485965922474861, -0.01858605071902275, 0.0115145826712250 ...\n",
-      "    document:         \"Pass your hand,\" I said, \"over the wall; you cannot help feelin ...\n",
-      "    metadata_blob:    {\"source\": \"texts/amontillado.txt\"}\n",
+      "    row_id:            21fbd9985564f7f12ac51f4c20232d75\n",
+      "    vector:            [-0.020231645554304123, 0.0051130387000739574, 0.009350934065878 ...\n",
+      "    body_blob:         \"Pass your hand,\" I said, \"over the wall; you cannot help feelin ...\n",
+      "    metadata_s:        {'source': 'texts/amontillado.txt'}\n",
       "\n",
       "Row 1:\n",
-      "    document_id:      f5020721820969b3fbf6b12691818508\n",
-      "    embedding_vector: [0.011451096273958683, -0.006945343688130379, -0.007215586956590 ...\n",
-      "    document:         No answer still.  I thrust a torch through the remaining apertur ...\n",
-      "    metadata_blob:    {\"source\": \"texts/amontillado.txt\"}\n",
+      "    row_id:            f5020721820969b3fbf6b12691818508\n",
+      "    vector:            [-0.01063380017876625, 0.00014423552784137428, 0.009167313575744 ...\n",
+      "    body_blob:         No answer still.  I thrust a torch through the remaining apertur ...\n",
+      "    metadata_s:        {'source': 'texts/amontillado.txt'}\n",
       "\n",
       "Row 2:\n",
-      "    document_id:      d2ff9ab96b181d455481c67f84558091\n",
-      "    embedding_vector: [-0.0056611113250255585, -0.0022278032265603542, 0.0493778288364 ...\n",
-      "    document:         I said to him--\"My dear Fortunato, you are luckily met.  How rem ...\n",
-      "    metadata_blob:    {\"source\": \"texts/amontillado.txt\"}\n",
+      "    row_id:            d2ff9ab96b181d455481c67f84558091\n",
+      "    vector:            [-0.015601841732859612, -0.005040594842284918, 0.020389072597026 ...\n",
+      "    body_blob:         I said to him--\"My dear Fortunato, you are luckily met.  How rem ...\n",
+      "    metadata_s:        {'source': 'texts/amontillado.txt'}\n",
       "\n",
       "...\n"
      ]
@@ -540,10 +540,19 @@
     "rows = session.execute(cqlSelect)\n",
     "for row_i, row in enumerate(rows):\n",
     "    print(f'\\nRow {row_i}:')\n",
-    "    print(f'    document_id:      {row.document_id}')\n",
-    "    print(f'    embedding_vector: {str(row.embedding_vector)[:64]} ...')\n",
-    "    print(f'    document:         {row.document[:64]} ...')\n",
-    "    print(f'    metadata_blob:    {row.metadata_blob}')\n",
+    "    # depending on the cassIO version, the underlying Cassandra table can have different structure ...\n",
+    "    try:\n",
+    "        # you are using the new cassIO 0.1.0+ : congratulations :)\n",
+    "        print(f'    row_id:            {row.row_id}')\n",
+    "        print(f'    vector:            {str(row.vector)[:64]} ...')\n",
+    "        print(f'    body_blob:         {row.body_blob[:64]} ...')\n",
+    "        print(f'    metadata_s:        {row.metadata_s}')        \n",
+    "    except AttributeError:\n",
+    "        # Please upgrade your cassIO to the latest version ...\n",
+    "        print(f'    document_id:      {row.document_id}')\n",
+    "        print(f'    embedding_vector: {str(row.embedding_vector)[:64]} ...')\n",
+    "        print(f'    document:         {row.document[:64]} ...')\n",
+    "        print(f'    metadata_blob:    {row.metadata_blob}')\n",
     "\n",
     "print('\\n...')"
    ]
@@ -565,7 +574,7 @@
     {
      "data": {
       "text/plain": [
-       "'Luchesi is a wine critic.'"
+       "' Luchesi is a connoisseur of wine who Fortunato believes can tell Amontillado from Sherry.'"
       ]
      },
      "execution_count": 10,
@@ -617,8 +626,8 @@
     {
      "data": {
       "text/plain": [
-       "[Document(page_content='He raised it to his lips with a leer.  He paused and nodded to me\\nfamiliarly, while his bells jingled.\\n\\n\"I drink,\" he said, \"to the buried that repose around us.\"\\n\\n\"And I to your long life.\"\\n\\nHe again took my arm, and we proceeded.\\n\\n\"These vaults,\" he said, \"are extensive.\"\\n\\n\"The Montresors,\" I replied, \"were a great and numerous family.\"\\n\\n\"I forget your arms.\"', metadata={'source': 'texts/amontillado.txt'}),\n",
-       " Document(page_content='\"A huge human foot d\\'or, in a field azure; the foot crushes a serpent\\nrampant whose fangs are imbedded in the heel.\"\\n\\n\"And the motto?\"\\n\\n\"_Nemo me impune lacessit_.\"\\n\\n\"Good!\" he said.', metadata={'source': 'texts/amontillado.txt'})]"
+       "[Document(page_content='\"A huge human foot d\\'or, in a field azure; the foot crushes a serpent\\nrampant whose fangs are imbedded in the heel.\"\\n\\n\"And the motto?\"\\n\\n\"_Nemo me impune lacessit_.\"\\n\\n\"Good!\" he said.', metadata={'source': 'texts/amontillado.txt'}),\n",
+       " Document(page_content='He raised it to his lips with a leer.  He paused and nodded to me\\nfamiliarly, while his bells jingled.\\n\\n\"I drink,\" he said, \"to the buried that repose around us.\"\\n\\n\"And I to your long life.\"\\n\\nHe again took my arm, and we proceeded.\\n\\n\"These vaults,\" he said, \"are extensive.\"\\n\\n\"The Montresors,\" I replied, \"were a great and numerous family.\"\\n\\n\"I forget your arms.\"', metadata={'source': 'texts/amontillado.txt'})]"
       ]
      },
      "execution_count": 12,

--- a/docs/frameworks/langchain/qa-basic.ipynb
+++ b/docs/frameworks/langchain/qa-basic.ipynb
@@ -95,7 +95,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LLM+embeddings from Vertex AI\n"
+      "LLM+embeddings from OpenAI\n"
      ]
     }
    ],
@@ -275,22 +275,22 @@
      "text": [
       "\n",
       "Row 0:\n",
-      "    document_id:      21fbd9985564f7f12ac51f4c20232d75\n",
-      "    embedding_vector: [-0.011485965922474861, -0.01858605071902275, 0.0115145826712250 ...\n",
-      "    document:         \"Pass your hand,\" I said, \"over the wall; you cannot help feelin ...\n",
-      "    metadata_blob:    {\"source\": \"texts/amontillado.txt\"}\n",
+      "    row_id:            21fbd9985564f7f12ac51f4c20232d75\n",
+      "    vector:            [-0.020231645554304123, 0.0051130387000739574, 0.009350934065878 ...\n",
+      "    body_blob:         \"Pass your hand,\" I said, \"over the wall; you cannot help feelin ...\n",
+      "    metadata_s:        {'source': 'texts/amontillado.txt'}\n",
       "\n",
       "Row 1:\n",
-      "    document_id:      f5020721820969b3fbf6b12691818508\n",
-      "    embedding_vector: [0.011451096273958683, -0.006945343688130379, -0.007215586956590 ...\n",
-      "    document:         No answer still.  I thrust a torch through the remaining apertur ...\n",
-      "    metadata_blob:    {\"source\": \"texts/amontillado.txt\"}\n",
+      "    row_id:            f5020721820969b3fbf6b12691818508\n",
+      "    vector:            [-0.01063380017876625, 0.00014423552784137428, 0.009167313575744 ...\n",
+      "    body_blob:         No answer still.  I thrust a torch through the remaining apertur ...\n",
+      "    metadata_s:        {'source': 'texts/amontillado.txt'}\n",
       "\n",
       "Row 2:\n",
-      "    document_id:      d2ff9ab96b181d455481c67f84558091\n",
-      "    embedding_vector: [-0.0056611113250255585, -0.0022278032265603542, 0.0493778288364 ...\n",
-      "    document:         I said to him--\"My dear Fortunato, you are luckily met.  How rem ...\n",
-      "    metadata_blob:    {\"source\": \"texts/amontillado.txt\"}\n",
+      "    row_id:            d2ff9ab96b181d455481c67f84558091\n",
+      "    vector:            [-0.015601841732859612, -0.005040594842284918, 0.020389072597026 ...\n",
+      "    body_blob:         I said to him--\"My dear Fortunato, you are luckily met.  How rem ...\n",
+      "    metadata_s:        {'source': 'texts/amontillado.txt'}\n",
       "\n",
       "...\n"
      ]
@@ -301,10 +301,19 @@
     "rows = session.execute(cqlSelect)\n",
     "for row_i, row in enumerate(rows):\n",
     "    print(f'\\nRow {row_i}:')\n",
-    "    print(f'    document_id:      {row.document_id}')\n",
-    "    print(f'    embedding_vector: {str(row.embedding_vector)[:64]} ...')\n",
-    "    print(f'    document:         {row.document[:64]} ...')\n",
-    "    print(f'    metadata_blob:    {row.metadata_blob}')\n",
+    "    # depending on the cassIO version, the underlying Cassandra table can have different structure ...\n",
+    "    try:\n",
+    "        # you are using the new cassIO 0.1.0+ : congratulations :)\n",
+    "        print(f'    row_id:            {row.row_id}')\n",
+    "        print(f'    vector:            {str(row.vector)[:64]} ...')\n",
+    "        print(f'    body_blob:         {row.body_blob[:64]} ...')\n",
+    "        print(f'    metadata_s:        {row.metadata_s}')        \n",
+    "    except AttributeError:\n",
+    "        # Please upgrade your cassIO to the latest version ...\n",
+    "        print(f'    document_id:      {row.document_id}')\n",
+    "        print(f'    embedding_vector: {str(row.embedding_vector)[:64]} ...')\n",
+    "        print(f'    document:         {row.document[:64]} ...')\n",
+    "        print(f'    metadata_blob:    {row.metadata_blob}')\n",
     "\n",
     "print('\\n...')"
    ]
@@ -326,7 +335,7 @@
     {
      "data": {
       "text/plain": [
-       "'Luchesi is a wine critic.'"
+       "' Luchesi is a connoisseur of wine who Fortunato believes can tell Amontillado from Sherry.'"
       ]
      },
      "execution_count": 10,
@@ -378,8 +387,8 @@
     {
      "data": {
       "text/plain": [
-       "[Document(page_content='He raised it to his lips with a leer.  He paused and nodded to me\\nfamiliarly, while his bells jingled.\\n\\n\"I drink,\" he said, \"to the buried that repose around us.\"\\n\\n\"And I to your long life.\"\\n\\nHe again took my arm, and we proceeded.\\n\\n\"These vaults,\" he said, \"are extensive.\"\\n\\n\"The Montresors,\" I replied, \"were a great and numerous family.\"\\n\\n\"I forget your arms.\"', metadata={'source': 'texts/amontillado.txt'}),\n",
-       " Document(page_content='\"A huge human foot d\\'or, in a field azure; the foot crushes a serpent\\nrampant whose fangs are imbedded in the heel.\"\\n\\n\"And the motto?\"\\n\\n\"_Nemo me impune lacessit_.\"\\n\\n\"Good!\" he said.', metadata={'source': 'texts/amontillado.txt'})]"
+       "[Document(page_content='\"A huge human foot d\\'or, in a field azure; the foot crushes a serpent\\nrampant whose fangs are imbedded in the heel.\"\\n\\n\"And the motto?\"\\n\\n\"_Nemo me impune lacessit_.\"\\n\\n\"Good!\" he said.', metadata={'source': 'texts/amontillado.txt'}),\n",
+       " Document(page_content='He raised it to his lips with a leer.  He paused and nodded to me\\nfamiliarly, while his bells jingled.\\n\\n\"I drink,\" he said, \"to the buried that repose around us.\"\\n\\n\"And I to your long life.\"\\n\\nHe again took my arm, and we proceeded.\\n\\n\"These vaults,\" he said, \"are extensive.\"\\n\\n\"The Montresors,\" I replied, \"were a great and numerous family.\"\\n\\n\"I forget your arms.\"', metadata={'source': 'texts/amontillado.txt'})]"
       ]
      },
      "execution_count": 12,


### PR DESCRIPTION
For a seamless switch to the new cassIO 0.1.0, the only place where the table is inspected with CQL statement is made compatible with both the new and the legacy table structure.