### PR TITLE
simplified and updated the naming around auth token/AstraCS auth pair

### DIFF
--- a/docs/frameworks/direct_cassio/.colab/colab_image_similarity_vectors.ipynb
+++ b/docs/frameworks/direct_cassio/.colab/colab_image_similarity_vectors.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -137,9 +137,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -148,8 +145,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/direct_cassio/.colab/colab_sound_similarity_vectors.ipynb
+++ b/docs/frameworks/direct_cassio/.colab/colab_sound_similarity_vectors.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -137,9 +137,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -148,8 +145,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/direct_cassio/cqlsession.py
+++ b/docs/frameworks/direct_cassio/cqlsession.py
@@ -14,7 +14,6 @@ dotenv_file = find_dotenv('.env')
 load_dotenv(dotenv_file)
 
 ASTRA_DB_SECURE_BUNDLE_PATH = os.environ["ASTRA_DB_SECURE_BUNDLE_PATH"]
-ASTRA_DB_CLIENT_ID = "token"
 ASTRA_DB_APPLICATION_TOKEN = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
 ASTRA_DB_KEYSPACE = os.environ["ASTRA_DB_KEYSPACE"]
 
@@ -27,7 +26,7 @@ def getCQLSession(mode='astra_db'):
                 "secure_connect_bundle": ASTRA_DB_SECURE_BUNDLE_PATH,
             },
             auth_provider=PlainTextAuthProvider(
-                ASTRA_DB_CLIENT_ID,
+                "token",
                 ASTRA_DB_APPLICATION_TOKEN,
             ),
         )

--- a/docs/frameworks/langchain/.colab/colab_caching-llm-responses.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_caching-llm-responses.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -125,9 +125,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -136,8 +133,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_chat-prompt-templates.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_chat-prompt-templates.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -122,9 +122,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -133,8 +130,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",
@@ -177,7 +174,7 @@
     "!./cqlsh-astra/bin/cqlsh \\\n",
     "    -b \"$ASTRA_DB_SECURE_BUNDLE_PATH\" \\\n",
     "    -u token \\\n",
-    "    -p \"$ASTRA_DB_TOKEN_BASED_PASSWORD\" \\\n",
+    "    -p \"$ASTRA_DB_APPLICATION_TOKEN\" \\\n",
     "    -k \"$ASTRA_DB_KEYSPACE\" \\\n",
     "    -f write_sample_data.cql"
    ]

--- a/docs/frameworks/langchain/.colab/colab_memory-basic.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_memory-basic.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -124,9 +124,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -135,8 +132,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_memory-conversationbuffermemory.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_memory-conversationbuffermemory.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -125,9 +125,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -136,8 +133,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_memory-summarybuffermemory.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_memory-summarybuffermemory.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -125,9 +125,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -136,8 +133,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_memory-vectorstore.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_memory-vectorstore.ipynb
@@ -76,7 +76,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -127,9 +127,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -138,8 +135,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_prompt-templates-basic.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_prompt-templates-basic.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -122,9 +122,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -133,8 +130,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",
@@ -177,7 +174,7 @@
     "!./cqlsh-astra/bin/cqlsh \\\n",
     "    -b \"$ASTRA_DB_SECURE_BUNDLE_PATH\" \\\n",
     "    -u token \\\n",
-    "    -p \"$ASTRA_DB_TOKEN_BASED_PASSWORD\" \\\n",
+    "    -p \"$ASTRA_DB_APPLICATION_TOKEN\" \\\n",
     "    -k \"$ASTRA_DB_KEYSPACE\" \\\n",
     "    -f write_sample_data.cql"
    ]

--- a/docs/frameworks/langchain/.colab/colab_prompt-templates-partialing.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_prompt-templates-partialing.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -122,9 +122,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -133,8 +130,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",
@@ -177,7 +174,7 @@
     "!./cqlsh-astra/bin/cqlsh \\\n",
     "    -b \"$ASTRA_DB_SECURE_BUNDLE_PATH\" \\\n",
     "    -u token \\\n",
-    "    -p \"$ASTRA_DB_TOKEN_BASED_PASSWORD\" \\\n",
+    "    -p \"$ASTRA_DB_APPLICATION_TOKEN\" \\\n",
     "    -k \"$ASTRA_DB_KEYSPACE\" \\\n",
     "    -f write_sample_data.cql"
    ]

--- a/docs/frameworks/langchain/.colab/colab_qa-advanced.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_qa-advanced.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -125,9 +125,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -136,8 +133,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_qa-basic.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_qa-basic.ipynb
@@ -76,7 +76,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -127,9 +127,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -138,8 +135,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_qa-maximal-marginal-relevance.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_qa-maximal-marginal-relevance.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -125,9 +125,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -136,8 +133,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/.colab/colab_semantic-caching-llm-responses.ipynb
+++ b/docs/frameworks/langchain/.colab/colab_semantic-caching-llm-responses.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -125,9 +125,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -136,8 +133,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/docs/frameworks/langchain/cqlsession.py
+++ b/docs/frameworks/langchain/cqlsession.py
@@ -14,7 +14,6 @@ dotenv_file = find_dotenv('.env')
 load_dotenv(dotenv_file)
 
 ASTRA_DB_SECURE_BUNDLE_PATH = os.environ["ASTRA_DB_SECURE_BUNDLE_PATH"]
-ASTRA_DB_CLIENT_ID = "token"
 ASTRA_DB_APPLICATION_TOKEN = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
 ASTRA_DB_KEYSPACE = os.environ["ASTRA_DB_KEYSPACE"]
 
@@ -27,7 +26,7 @@ def getCQLSession(mode='astra_db'):
                 "secure_connect_bundle": ASTRA_DB_SECURE_BUNDLE_PATH,
             },
             auth_provider=PlainTextAuthProvider(
-                ASTRA_DB_CLIENT_ID,
+                "token",
                 ASTRA_DB_APPLICATION_TOKEN,
             ),
         )

--- a/nbUtils/colab_snippets/colab_setup_db.json
+++ b/nbUtils/colab_snippets/colab_setup_db.json
@@ -20,7 +20,7 @@
    "source": [
     "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
     "from getpass import getpass\n",
-    "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
+    "ASTRA_DB_APPLICATION_TOKEN = getpass('Your Astra DB Token (\"AstraCS:...\"): ')"
    ]
   },
   {
@@ -74,9 +74,6 @@
     ")\n",
     "from cassandra.auth import PlainTextAuthProvider\n",
     "\n",
-    "# The \"username\" is the literal string 'token' for this connection mode:\n",
-    "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
-    "\n",
     "\n",
     "def getCQLSession(mode='astra_db'):\n",
     "    if mode == 'astra_db':\n",
@@ -85,8 +82,8 @@
     "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
     "            },\n",
     "            auth_provider=PlainTextAuthProvider(\n",
-    "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
-    "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+    "                \"token\",\n",
+    "                ASTRA_DB_APPLICATION_TOKEN,\n",
     "            ),\n",
     "        )\n",
     "        astraSession = cluster.connect()\n",

--- a/nbUtils/colab_snippets/colab_setup_provision_db.json
+++ b/nbUtils/colab_snippets/colab_setup_provision_db.json
@@ -31,7 +31,7 @@
     "!./cqlsh-astra/bin/cqlsh \\\n",
     "    -b \"$ASTRA_DB_SECURE_BUNDLE_PATH\" \\\n",
     "    -u token \\\n",
-    "    -p \"$ASTRA_DB_TOKEN_BASED_PASSWORD\" \\\n",
+    "    -p \"$ASTRA_DB_APPLICATION_TOKEN\" \\\n",
     "    -k \"$ASTRA_DB_KEYSPACE\" \\\n",
     "    -f write_sample_data.cql"
    ]


### PR DESCRIPTION
This removes storing the literal `"token"` in any variable and puts it directly in the argument to the auth when creating the Astra session. Previously it was called "CLIENT_ID"-something, which caused much confusion.

Done on both the local-run `cqlsession.py` and in the colab (through the json snippets in the colabifier).

Also made the token variable name uniform across colab and cqlsession.py: it's called `ASTRA_DB_APPLICATION_TOKEN` everywhere, in line with the Astra docs/quickstart (for the corresponding "token"/"AstraCS:..." auth pathway) and with the output of `astra db create-dotenv...` command.