### PR TITLE
Use latest 5.x C* version by default

### DIFF
--- a/docs/more_info.md
+++ b/docs/more_info.md
@@ -90,17 +90,17 @@ Docker. First make sure you have Docker [installed](https://www.docker.com/),
 then launch the following command:
 
 ```bash
-docker run --name my-cassandra -d cassandra:5.0-alpha2
+docker run --name my-cassandra -d cassandra:5
 ```
 
 In the command above, you can name the container any way you like:
 but keep in mind that the instructions on this page assume you
 used `my-cassandra`.
 
-The `5.0-alpha2`
+The `5`
 is an image tag: you may want to check Cassandra's
 [DockerHub page](https://hub.docker.com/_/cassandra#!)
-for the newest `5.*` tag to use.
+for the newest beyond `5.*` tag to use.
 
 In a few minutes, the container will be up and running, ready to be used. You
 can verify this by running `docker exec -it my-cassandra  nodetool status` and


### PR DESCRIPTION
Automatically use the latest [Cassandra `5` Docker image version](https://hub.docker.com/layers/library/cassandra/5/images/sha256-af0b731a0f75c8aab4fd8b09df9d11b5afaa365323c62a54591990c9fbe88bff?context=explore).